### PR TITLE
Simple (probable) vestigial dependency drop

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -76,7 +76,6 @@ task :gemspec do
             spec.has_rdoc = #{ has_rdoc.inspect }
             spec.test_files = #{ test_files.inspect }
             #spec.add_dependency 'lib', '>= version'
-            spec.add_dependency 'fattr'
 
             spec.extensions.push(*#{ extensions.inspect })
 

--- a/gemspec.rb
+++ b/gemspec.rb
@@ -47,7 +47,6 @@ template = <<-__
     spec.has_rdoc = #{ has_rdoc.inspect }
     spec.test_files = #{ test_files.inspect }
     #spec.add_dependency 'lib', '>= version'
-    #spec.add_dependency 'fattr'
 
     spec.extensions.push(*#{ extensions.inspect })
 


### PR DESCRIPTION
Hi there,

In Gentoo we started respecting more strictly by default the dependencies listed in gemspecs, and it turns out that session has a dependency on fattr there that doesn't seem to be needed by the code at all. This should solve it for the next version, if you'd like to merge it.

Thanks!
Diego
